### PR TITLE
Libcst migrations

### DIFF
--- a/SHA256.1.py
+++ b/SHA256.1.py
@@ -1,0 +1,94 @@
+from Crypto.Util.py3compat import bord
+from Crypto.Util._raw_api import (
+    load_pycryptodome_raw_lib,
+    VoidPointer,
+    SmartPointer,
+    create_string_buffer,
+    get_raw_buffer,
+    c_size_t,
+    c_uint8_ptr,
+)
+
+_raw_sha256_lib = load_pycryptodome_raw_lib(
+    "Crypto.Hash._SHA256",
+    "\n                        int SHA256_init(void **shaState);\n                        int SHA256_destroy(void *shaState);\n                        int SHA256_update(void *hs,\n                                          const uint8_t *buf,\n                                          size_t len);\n                        int SHA256_digest(const void *shaState,\n                                          uint8_t *digest,\n                                          size_t digest_size);\n                        int SHA256_copy(const void *src, void *dst);\n\n                        int SHA256_pbkdf2_hmac_assist(const void *inner,\n                                            const void *outer,\n                                            const uint8_t *first_digest,\n                                            uint8_t *final_digest,\n                                            size_t iterations,\n                                            size_t digest_size);\n                        ",
+)
+"A SHA-256 hash object.\n    Do not instantiate directly. Use the :func:`new` function.\n\n    :ivar oid: ASN.1 Object ID\n    :vartype oid: string\n\n    :ivar block_size: the size in bytes of the internal message block,\n                      input to the compression function\n    :vartype block_size: integer\n\n    :ivar digest_size: the size in bytes of the resulting hash\n    :vartype digest_size: integer\n    "
+digest_size = 32
+block_size = 64
+oid = "2.16.840.1.101.3.4.2.1"
+
+
+def __init__(self, data=None):
+    state = VoidPointer()
+    result = _raw_sha256_lib.SHA256_init(state.address_of())
+    if result:
+        raise ValueError(("Error %d while instantiating SHA256" % result))
+    self._state = SmartPointer(state.get(), _raw_sha256_lib.SHA256_destroy)
+    if data:
+        self.update(data)
+
+
+def update(self, data):
+    "Continue hashing of a message by consuming the next chunk of data.\n\n        Args:\n            data (byte string/byte array/memoryview): The next chunk of the message being hashed.\n        "
+    result = _raw_sha256_lib.SHA256_update(
+        self._state.get(), c_uint8_ptr(data), c_size_t(len(data))
+    )
+    if result:
+        raise ValueError(("Error %d while hashing data with SHA256" % result))
+
+
+def digest(self):
+    "Return the **binary** (non-printable) digest of the message that has been hashed so far.\n\n        :return: The hash digest, computed over the data processed so far.\n                 Binary form.\n        :rtype: byte string\n        "
+    bfr = create_string_buffer(self.digest_size)
+    result = _raw_sha256_lib.SHA256_digest(
+        self._state.get(), bfr, c_size_t(self.digest_size)
+    )
+    if result:
+        raise ValueError(("Error %d while making SHA256 digest" % result))
+    return get_raw_buffer(bfr)
+
+
+def hexdigest(self):
+    "Return the **printable** digest of the message that has been hashed so far.\n\n        :return: The hash digest, computed over the data processed so far.\n                 Hexadecimal encoded.\n        :rtype: string\n        "
+    return "".join([("%02x" % bord(x)) for x in self.digest()])
+
+
+def copy(self):
+    'Return a copy ("clone") of the hash object.\n\n        The copy will have the same internal state as the original hash\n        object.\n        This can be used to efficiently compute the digests of strings that\n        share a common initial substring.\n\n        :return: A hash object of the same type\n        '
+    clone = SHA256Hash()
+    result = _raw_sha256_lib.SHA256_copy(self._state.get(), clone._state.get())
+    if result:
+        raise ValueError(("Error %d while copying SHA256" % result))
+    return clone
+
+
+def new(self, data=None):
+    "Create a fresh SHA-256 hash object."
+    return SHA256Hash(data)
+
+
+def new(data=None):
+    "Create a new hash object.\n\n    :parameter data:\n        Optional. The very first chunk of the message to hash.\n        It is equivalent to an early call to :meth:`SHA256Hash.update`.\n    :type data: byte string/byte array/memoryview\n\n    :Return: A :class:`SHA256Hash` hash object\n    "
+    return SHA256Hash().new(data)
+
+
+digest_size = SHA256Hash.digest_size
+block_size = SHA256Hash.block_size
+
+
+def _pbkdf2_hmac_assist(inner, outer, first_digest, iterations):
+    "Compute the expensive inner loop in PBKDF-HMAC."
+    assert iterations > 0
+    bfr = create_string_buffer(len(first_digest))
+    result = _raw_sha256_lib.SHA256_pbkdf2_hmac_assist(
+        inner._state.get(),
+        outer._state.get(),
+        first_digest,
+        bfr,
+        c_size_t(iterations),
+        c_size_t(len(first_digest)),
+    )
+    if result:
+        raise ValueError(("Error %d with PBKDF2-HMAC assist for SHA256" % result))
+    return get_raw_buffer(bfr)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,4 @@
 astunparse==1.6.3
-# https://stackoverflow.com/a/54794506/133514
-astor@git+git://github.com/berkerpeksag/astor.git@master#egg=astor
-gast@git+git://github.com/serge-sans-paille/gast.git@master#egg=gast
 future==0.18.2
 lib3to6==202101.1045
 libcst==0.3.17
-asttokens==2.0.4
-astpretty==2.1.0

--- a/src/py2star/asteez/remove_self.py
+++ b/src/py2star/asteez/remove_self.py
@@ -1,18 +1,27 @@
-import ast
+import libcst as ast
+from libcst import codemod
 
 
 def get_name(attribute_node):
+    if isinstance(attribute_node, str):
+        return attribute_node
     if isinstance(attribute_node, ast.Name):
         return attribute_node.id
     if isinstance(attribute_node, ast.Call):
         return get_name(attribute_node.func)
     if not hasattr(attribute_node, "value"):
         return attribute_node.id
-    return get_name(attribute_node.value) + "." + attribute_node.attr
+
+    if not hasattr(attribute_node, "attr"):
+        attr = str(attribute_node)
+    else:
+        attr = attribute_node.attr
+    return get_name(attribute_node.value) + "." + attr
 
 
-class AttributeRenamer(ast.NodeTransformer):
-    def __init__(self, substitutes):
+class AttributeRenamer(codemod.VisitorBasedCodemodCommand):
+    def __init__(self, context, substitutes):
+        super(AttributeRenamer, self).__init__(context)
         self.substitutes = substitutes
 
     def visit_Name(self, node):

--- a/src/py2star/asteez/remove_self.py
+++ b/src/py2star/asteez/remove_self.py
@@ -29,9 +29,8 @@ class FunctionParameterStripper(codemod.VisitorBasedCodemodCommand):
 
 
 class AttributeGetter(codemod.VisitorBasedCodemodCommand):
-    """
-    AttributeGetter(["self"]): self.foo => foo
-    """
+
+    DESCRIPTION = "AttributeGetter(ctx, ['self']): self.foo() => foo()"
 
     def __init__(self, context: CodemodContext, namespace: typing.List):
         super(AttributeGetter, self).__init__(context)

--- a/src/py2star/asteez/remove_self.py
+++ b/src/py2star/asteez/remove_self.py
@@ -1,65 +1,49 @@
+import typing
+
 import libcst as ast
+import libcst.matchers as m
 from libcst import codemod
+from libcst.codemod import CodemodContext
 
 
-def get_name(attribute_node):
-    if isinstance(attribute_node, str):
-        return attribute_node
-    if isinstance(attribute_node, ast.Name):
-        return attribute_node.id
-    if isinstance(attribute_node, ast.Call):
-        return get_name(attribute_node.func)
-    if not hasattr(attribute_node, "value"):
-        return attribute_node.id
+class FunctionParameterStripper(codemod.VisitorBasedCodemodCommand):
 
-    if not hasattr(attribute_node, "attr"):
-        attr = str(attribute_node)
-    else:
-        attr = attribute_node.attr
-    return get_name(attribute_node.value) + "." + attr
+    DESCRIPTION = "Strips configured params from function signatures"
 
+    def __init__(self, context: CodemodContext, params: typing.List):
+        super(FunctionParameterStripper, self).__init__(context)
+        self.params = [m.Name(n) for n in params]
 
-class AttributeRenamer(codemod.VisitorBasedCodemodCommand):
-    def __init__(self, context, substitutes):
-        super(AttributeRenamer, self).__init__(context)
-        self.substitutes = substitutes
+    def leave_FunctionDef(
+        self, original_node: ast.FunctionDef, updated_node: ast.FunctionDef
+    ) -> typing.Union[ast.BaseStatement, ast.RemovalSentinel]:
+        modified_params = []
+        for param in updated_node.params.params:
+            if m.matches(param, m.Param(name=m.OneOf(*self.params))):
+                continue
+            modified_params.append(param)
 
-    def visit_Name(self, node):
-        return self.visit_Attribute(node)
-
-    def visit_Attribute(self, node):
-        name = get_name(node)
-        if name in self.substitutes:
-            return self.substitutes[name]
-        return node
+        return updated_node.with_changes(
+            params=updated_node.params.with_changes(params=modified_params)
+        )
 
 
-class FunctionParameterStripper(ast.NodeTransformer):
-    def __init__(self, params):
-        self.params = params
-
-    def visit_arguments(self, node: ast.arguments):
-        node.args = [arg for arg in node.args if arg.arg not in self.params]
-        return node
-
-
-class AttributeGetter(ast.NodeTransformer):
+class AttributeGetter(codemod.VisitorBasedCodemodCommand):
     """
     AttributeGetter(["self"]): self.foo => foo
     """
 
-    def __init__(self, namespace):
-        self.namespace = namespace
+    def __init__(self, context: CodemodContext, namespace: typing.List):
+        super(AttributeGetter, self).__init__(context)
+        self.namespace = [m.Name(n) for n in namespace]
 
-    def get_value(self, node):
-        name = get_name(node)
-        attributes = name.split(".")
-        if attributes[0] in self.namespace:
-            # obj = self.namespace[attributes.pop(0)]
-            # return ast.parse(repr(obj)).body[0].value
-            obj = ".".join(attributes[1:])
-            return ast.Name(obj, ctx=ast.Load())
-
-    def visit_Attribute(self, node):
-        val = self.get_value(node)
-        return val if val is not None else node
+    def leave_Attribute(
+        self, original_node: ast.Attribute, updated_node: ast.Attribute
+    ) -> typing.Union[ast.Attribute, ast.RemovalSentinel]:
+        if m.matches(updated_node, m.Attribute(value=m.OneOf(*self.namespace))):
+            return updated_node.with_changes(
+                value=updated_node.attr,
+                attr=ast.SimpleWhitespace(value=""),
+                dot=ast.SimpleWhitespace(value=""),
+            )
+        return updated_node

--- a/src/py2star/asteez/rewrite_loopz.py
+++ b/src/py2star/asteez/rewrite_loopz.py
@@ -1,74 +1,83 @@
-import ast
+import libcst as ast
 import sys
+
+import typing
+
+from birdseye import eye
+from libcst import codemod
 
 
 def invert(node):
 
     inverse = {
-        ast.Eq: ast.NotEq,
-        ast.NotEq: ast.Eq,
-        ast.Lt: ast.GtE,
-        ast.LtE: ast.Gt,
-        ast.Gt: ast.LtE,
-        ast.GtE: ast.Lt,
+        ast.Equal: ast.NotEqual,
+        ast.NotEqual: ast.Equal,
+        ast.LessThan: ast.GreaterThanEqual,
+        ast.LessThanEqual: ast.GreaterThan,
+        ast.GreaterThan: ast.LessThanEqual,
+        ast.GreaterThanEqual: ast.LessThan,
         ast.Is: ast.IsNot,
         ast.IsNot: ast.Is,
         ast.In: ast.NotIn,
         ast.NotIn: ast.In,
     }
 
-    if type(node) == ast.Compare:
-        op = type(node.ops[0])
-        inverse_node = ast.Compare(
-            left=node.left, ops=[inverse[op]()], comparators=node.comparators
+    if type(node) == ast.Comparison:
+        op = type(node.comparisons[0].operator)
+        inverse_node = ast.Comparison(
+            left=node.left,
+            comparisons=[
+                ast.ComparisonTarget(
+                    inverse[op](), node.comparisons[0].comparator
+                )
+            ],
         )
-    elif type(node) == ast.NameConstant and node.value in [True, False]:
-        inverse_node = ast.NameConstant(value=not node.value)
+    elif type(node) == ast.Name and node.value in [True, False]:
+        inverse_node = ast.Name(value=f"{not node.value}")
     else:
-        inverse_node = ast.UnaryOp(op=ast.Not(), operand=node)
+        inverse_node = ast.UnaryOperation(operator=ast.Not(), expression=node)
 
     return inverse_node
 
 
-class WhileToForLoop(ast.NodeTransformer):
-    def visit_While(self, node):
+class WhileToForLoop(codemod.VisitorBasedCodemodCommand):
+    @eye
+    def leave_While(
+        self, original_node: ast.While, updated_node: ast.While
+    ) -> typing.Union[ast.BaseStatement, ast.RemovalSentinel]:
         try:
-            inverse_node = invert(node.test)
+            inverse_node = invert(updated_node.test)
         except (AttributeError, IndexError) as e:
-            print("Cannot convert this loop: ", node, e, file=sys.stderr)
-            return node
+            print(
+                "Cannot convert this loop: ", updated_node, e, file=sys.stderr
+            )
+            return updated_node
 
-        new_for = ast.For(
-            target=ast.Name(id="_while_", ctx=ast.Store()),
-            iter=ast.Call(
-                func=ast.Name(id="range", ctx=ast.Load()),
-                args=[
-                    ast.Name(
-                        id="_WHILE_LOOP_EMULATION_ITERATION", ctx=ast.Load()
-                    )
-                ],
-                keywords=[],
+        block: ast.IndentedBlock = updated_node.body
+        new_body = list(block.body)
+        new_body.insert(
+            0,
+            ast.If(
+                test=inverse_node,
+                body=ast.IndentedBlock(
+                    body=[ast.SimpleStatementLine(body=[ast.Break()])]
+                ),
+                orelse=None,
             ),
-            body=[
-                ast.If(
-                    test=inverse_node,
-                    body=[ast.Break()],
-                    orelse=[],
-                )
-            ]
-            + node.body,
-            orelse=[],
-            type_comment=None,
         )
-        new_for = ast.fix_missing_locations(new_for)
-        return new_for
-        # while pos <= finish:
-        #    m = self.search(s, pos)
-        print(node.test)
-        print(node.body)
-        print(node.orelse)
-
-        return node
-
-    def visit_For(self, node):
-        return node
+        as_for = ast.For(
+            target=ast.Name(value="_while_"),
+            iter=ast.Call(
+                func=ast.Name(value="range"),
+                args=[
+                    ast.Arg(value=ast.Name("_WHILE_LOOP_EMULATION_ITERATION"))
+                ],
+            ),
+            body=ast.IndentedBlock(
+                body=new_body,
+                footer=block.footer,
+                header=block.header,
+            ),
+            orelse=None,
+        )
+        return updated_node.deep_replace(updated_node, as_for)

--- a/src/py2star/asteez/rewrite_loopz.py
+++ b/src/py2star/asteez/rewrite_loopz.py
@@ -2,20 +2,6 @@ import ast
 import sys
 
 
-def genIterateCollectionLoop(
-    listVar: ast.Attribute, iterVarName: str, yieldBody: ast.Attribute
-) -> ast.For:
-
-    res = ast.For(
-        target=ast.Name(id="_while_", ctx=ast.Store()),
-        iter=ast.comprehension(),
-        body=[ast.Expr(value=ast.Yield(value=yieldBody))],
-        orelse=[],
-        type_comment=None,
-    )
-    return res
-
-
 def invert(node):
 
     inverse = {

--- a/src/py2star/cli.py
+++ b/src/py2star/cli.py
@@ -1,19 +1,14 @@
 import argparse
 import ast
-import inspect
 import logging
-import string
 import sys
-import textwrap
 from lib2to3 import refactor
 
 import astunparse
-from py2star import asteez
 from py2star.asteez import (
     functionz,
     remove_self,
     rewrite_chained_comparisons,
-    rewrite_fstring,
     rewrite_loopz,
 )
 from py2star.tokenizers import find_definitions

--- a/src/py2star/cli.py
+++ b/src/py2star/cli.py
@@ -4,7 +4,6 @@ import logging
 import sys
 from lib2to3 import refactor
 
-import astunparse
 import libcst
 from libcst.codemod import CodemodContext
 from py2star.asteez import (

--- a/src/py2star/cli.py
+++ b/src/py2star/cli.py
@@ -118,7 +118,7 @@ def larkify(filename, fixers, astrw):
     for l in [
         remove_self.FunctionParameterStripper(context, ["self"]),
         remove_self.AttributeGetter(context, ["self"]),
-        # rewrite_loopz.WhileToForLoop(),
+        rewrite_loopz.WhileToForLoop(context),
         functionz.GeneratorToFunction(context),
         rewrite_chained_comparisons.UnchainComparison(context),
     ]:

--- a/src/py2star/fixes/fix_declass.py
+++ b/src/py2star/fixes/fix_declass.py
@@ -1,59 +1,17 @@
 from lib2to3.fixer_base import BaseFix
 from lib2to3.fixer_util import token, find_indentation
 
-
-def safe_dedent(prefix, dedent_len):
-    """
-    Dedent the prefix of a dedent token at the start of a line.
-
-    Non-syntactically meaningful newlines before tokens are appended to the
-     prefix of the following token.
-
-    This avoids removing the newline part of the prefix when the token
-    dedents to below the given level of indentation.
-
-    :param prefix:  prefix of a dedent token
-    :param dedent_len:
-    :return:
-    """
-    """
-
-    """
-    for i, c in enumerate(prefix):
-        if c not in "\r\n":
-            break
-    else:
-        i = len(prefix)
-    return prefix[:i] + prefix[i:-dedent_len]
-
-
-def dedent_suite(suite, dedent):
-    """Dedent a suite in-place."""
-    leaves = suite.leaves()
-    for leaf in leaves:
-        if leaf.type == token.NEWLINE:
-            leaf = next(leaves, None)
-            if leaf is None:
-                return
-            if leaf.type == token.INDENT:
-                leaf.value = leaf.value[:-dedent]
-            else:
-                # this prefix will start with any duplicate newlines
-                leaf.prefix = safe_dedent(leaf.prefix, dedent)
-        elif leaf.type == token.INDENT:
-            leaf.value = leaf.value[:-dedent]
-        elif leaf.prefix.startswith(("\r", "\n")):
-            leaf.prefix = leaf.prefix[:-dedent]
+from py2star.utils import dedent_suite
 
 
 class FixDeclass(BaseFix):
     order = "pre"
-    run_order = 7  # Fixers will be sorted by run order before execution
+    run_order = 6  # Fixers will be sorted by run order before execution
     # Lower numbers will be run first.
 
     PATTERN = """
       classdef< 'class' name=any ['(' 
-           (power< 'unittest' trailer< '.' 'TestCase' > > | 'TestCase')
+           ('object')
       ')'] ':'
          suite=suite
       >

--- a/src/py2star/fixes/fix_unittests.py
+++ b/src/py2star/fixes/fix_unittests.py
@@ -1,0 +1,20 @@
+from lib2to3.fixer_base import BaseFix
+from lib2to3.fixer_util import token, find_indentation
+
+from py2star.utils import dedent_suite
+
+from .fix_declass import FixDeclass
+
+
+class FixUnittests(FixDeclass):
+    order = "pre"
+    run_order = 7  # Fixers will be sorted by run order before execution
+    # Lower numbers will be run first.
+
+    PATTERN = """
+      classdef< 'class' name=any ['(' 
+           (power< 'unittest' trailer< '.' 'TestCase' > > | 'TestCase')
+      ')'] ':'
+         suite=suite
+      >
+    """

--- a/tests/simple_class.py
+++ b/tests/simple_class.py
@@ -19,7 +19,7 @@ class RewriteMe(TestCase):
         pass
 
     def write(self):
-        pass
+        return self.__dict__.get("foo")
 
     def do_it(self):
         x = b"foo"

--- a/tests/test_asteez.py
+++ b/tests/test_asteez.py
@@ -70,7 +70,7 @@ def test_convert_while_loop():
     While loop converted to for loop because there's no while loops in starlark
     :return:
     """
-    s = ast.parse(
+    s = cst.parse_module(
         """
 pos = 0
 finish = 5
@@ -79,25 +79,27 @@ while pos <= finish:
     if not m:
         res += s[pos:]
         break    
+        
     """
     )
-    expected = """
+    expected = cst.parse_module(
+        """
 pos = 0
 finish = 5
 for _while_ in range(_WHILE_LOOP_EMULATION_ITERATION):
-    if (pos > finish):
+    if pos > finish:
         break
     m = self.search(s, pos)
-    if (not m):
+    if not m:
         res += s[pos:]
-        break     
+        break 
+            
     """
-    # print(astunparse.unparse(ast.parse(expected)))
-    sut = ast.parse(s)
-    # d astpretty.pprint(sut)
-    w2f = rewrite_loopz.WhileToForLoop()
-    rewritten = w2f.visit(sut)
-    assert expected.strip() == astunparse.unparse(rewritten).strip()
+    )
+    ctx = CodemodContext()
+    w2f = rewrite_loopz.WhileToForLoop(ctx)
+    rewritten = s.visit(w2f)
+    assert expected.code.strip() == rewritten.code.strip()
 
 
 def test_generator_to_comprehension():

--- a/tests/test_asteez.py
+++ b/tests/test_asteez.py
@@ -102,19 +102,20 @@ for _while_ in range(_WHILE_LOOP_EMULATION_ITERATION):
 
 
 def test_generator_to_comprehension():
-    s = ast.parse(
+    context = CodemodContext()
+    tree = cst.parse_module(
         """
 c = range(12)
 x = (i for i in c)
-    """
+"""
     )
-    gf = functionz.GeneratorToFunction()
-    rewritten = gf.visit(s)
+    gf = functionz.GeneratorToFunction(context)
+    rewritten = tree.visit(gf)
     expected = """
 c = range(12)
 x = [i for i in c]
 """
-    assert expected == astunparse.unparse(rewritten)
+    assert expected == str(rewritten.code)
 
 
 def test_unchain_comparison():

--- a/tests/test_asteez.py
+++ b/tests/test_asteez.py
@@ -53,14 +53,17 @@ def test_remove_types(source_tree):
     print(rewritten.code)
 
 
-def test_remove_self(toplevel_functions):
-    tree = toplevel_functions
+def test_remove_self(source_tree):
+    context = CodemodContext()
+    tree = source_tree
     for l in [
-        remove_self.FunctionParameterStripper(["self"]),
-        remove_self.AttributeGetter(["self"]),
+        remove_self.FunctionParameterStripper(context, ["self"]),
+        remove_self.AttributeGetter(context, ["self"]),
     ]:
-        tree = l.visit(tree)
-    print(astunparse.unparse(tree))
+        tree = tree.visit(l)
+
+    # print(tree.code)
+    assert "self" not in tree.code
 
 
 def test_convert_while_loop():

--- a/tests/toplevelfunctions.py
+++ b/tests/toplevelfunctions.py
@@ -8,6 +8,9 @@ def bar(q, w, z):
 
 
 def bar(baz):
+    # comment
+    # multi-line
+    # fix
     pass
 
 


### PR DESCRIPTION
Migrate all the py2star ast rewrites to libcst instead to preserve the comments etc.